### PR TITLE
Small changes to Optimizer

### DIFF
--- a/TMBhelper/R/Optimize.R
+++ b/TMBhelper/R/Optimize.R
@@ -22,7 +22,7 @@
 
 #' @export
 Optimize = function( obj, fn=obj$fn, gr=obj$gr, startpar=obj$par, lower=rep(-Inf,length(startpar)), upper=rep(Inf,length(startpar)),
-  getsd=TRUE, control=list(eval.max=1e4, iter.max=1e4, trace=TRUE),
+  getsd=TRUE, control=list(eval.max=1e4, iter.max=1e4, trace=0),
   savedir=NULL, loopnum=3, newtonsteps=0, n=Inf, ... ){
 
   # Run first time

--- a/TMBhelper/R/Optimize.R
+++ b/TMBhelper/R/Optimize.R
@@ -44,6 +44,7 @@ Optimize = function( obj, fn=obj$fn, gr=obj$gr, startpar=obj$par, lower=rep(-Inf
 
   # Add diagnostics
   opt[["run_time"]] = Sys.time() - start_time
+  opt[["max_gradient"]] = max(abs(obj$gr(opt$par)))
   opt[["number_of_coefficients"]] = c("Total"=length(unlist(obj$env$parameters)), "Fixed"=length(obj$par), "Random"=length(unlist(obj$env$parameters))-length(obj$par) )
   opt[["AIC"]] = TMBhelper::TMBAIC( opt=opt )
   if( n!=Inf ){


### PR DESCRIPTION
I turned off trace by default. It's weird to have it be TRUE by default, when nlminb is expecting an integer (how often to print trace), so this gets evaluated to 1. I propose setting it to 0 to cleanup console output by default.

I also added a named element max_gradient which can be convenient to quickly check.